### PR TITLE
Update octopus-printer.cfg

### DIFF
--- a/Firmware/octopus-printer.cfg
+++ b/Firmware/octopus-printer.cfg
@@ -530,6 +530,7 @@ gcode:
 [gcode_macro PRINT_START]
 #   Use PRINT_START for the slicer starting script - please customise for your slicer of choice
 gcode:
+    G90
     G32                            ; home all axes
     G1 Z20 F3000                   ; move nozzle away from bed
    


### PR DESCRIPTION
I ran into an issue where I ended up with a `Move out of range: 357.500 450.000 40.000 [198.000]` error after the G32 finishes. 

This is using SuperSlicer Version 2.3.57 with the stock Voron 2.4 300mm profiles. Not exactly sure how I managed to get this to happen as I have printed with these profiles successfully just minutes before.

Seems the gcode/printer somehow ends up in relative positioning, and @chun in #slicers_and_print_help on the Voron discord suggested to add a G90 to the PRINT_START macro.
Figured I'd mention it here in case that is somehow we would want as a default in case others also run into this :-)

PS: Edited this in the browser just quick, not sure how the last line got altered with a whitespace/newline, I did not add one on purpose.