### PR TITLE
reduce ACC to a sane value of 3000

### DIFF
--- a/Firmware/octopus-printer.cfg
+++ b/Firmware/octopus-printer.cfg
@@ -32,7 +32,7 @@ restart_method: command
 [printer]
 kinematics: corexy
 max_velocity: 500  
-max_accel: 10000
+max_accel: 3000
 max_z_velocity: 15          #Max 15 for 12V TMC Drivers, can increase for 24V
 max_z_accel: 350
 square_corner_velocity: 5.0


### PR DESCRIPTION
Reduce the default acceleration from 10000 to 3000. The name of the parameter is misleading: This used to be a maximum value, but nowadays it is just a default value. 10000 ACC as a default on a non-tuned V2.4 is a bad move. People who use Cura or other slicers without acceleration control get bad prints with this. 

This is not an upper limit. You can put 3000 in the printer.cfg, and if you use a slicer with acceleration control like SuperSlicer or Prusaslicer, use any value in the slicer. If the user choses 10000 in his profile, the printer will then use 10000 for the print. He won't need to up the value in the printer.cfg.