### PR TITLE
Add missing thermistor definition section

### DIFF
--- a/Firmware/leviathan-printer-rev-d.cfg
+++ b/Firmware/leviathan-printer-rev-d.cfg
@@ -423,6 +423,14 @@ probe_points:
 #####################################################################
 #   TH
 # #####################################################################
+[thermistor CMFB103F3950FANT]
+temperature1: 0.0
+resistance1: 32116.0
+temperature2: 40.0
+resistance2: 5309.0
+temperature3: 80.0
+resistance3: 1228.0
+
 [temperature_sensor chamber_temp]
 ## Chamber Temperature - T1
 sensor_type: ATC Semitec 104NT-4-R025H42G


### PR DESCRIPTION
CMFB103F3950FANT is specified as the sensor_type for the chamber thermistor but it is missing.

This PR adds it, copied the definition from the Nitehawk-SB repository.